### PR TITLE
Tabular temp fix

### DIFF
--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -299,12 +299,12 @@
     'patterns': [
       {
         'match': '\\\\\\\\'
-        'name': 'punctuation.definition.table.row.latex'
+        'name': 'punctuation.definition.table.row2.latex'
       }
       {
         'begin': '(?:^|(?<=\\\\\\\\))(?!\\\\\\\\|\\s*\\\\end\\{(?:tabular|array))'
         'end': '(?=\\\\\\\\|\\s*\\\\end\\{(?:tabular|array))'
-        'name': 'meta.row.environment.tabular.latex'
+        'name': 'meta.row2.environment.tabular.latex'
         'patterns': [
           {
             'match': '&'


### PR DESCRIPTION
Temporary fix for extra spaces added when using tabular environment (cf
https://github.com/area/language-latex/issues/4)
