### PR TITLE
Toggle line comment fix

### DIFF
--- a/scoped-properties/language-latex.cson
+++ b/scoped-properties/language-latex.cson
@@ -1,6 +1,7 @@
 '.text.tex':
   'editor':
     'foldEndPattern': '\\*\\*/|^\\s*\\}'
+    'commentStart': '% '
 '.text.bibtex':
   'editor':
     'foldEndPattern': '^\\s*[)}]\\s*$'


### PR DESCRIPTION
Fixing the action of ‘Editor -> Toggle Line Comment’ menu entry (cf
https://github.com/area/language-latex/issues/7)
