### PR TITLE
Added table and figure floats

### DIFF
--- a/snippets/language-latex.cson
+++ b/snippets/language-latex.cson
@@ -69,6 +69,12 @@
   '\\begin{}…\\end{}':
     'prefix': 'begin'
     'body': '\\begin{${1:env}}\n\t$2\n\\end{${1:env}}'
+  'Figure float':
+    'prefix': 'ffig'
+    'body': '\\begin{figure}[htbp]\n\t\\includegraphics{$1}\n\t\\caption{$2}\n\t\\label{fig:$3}\n\\end{figure}'
+  'Table float':
+    'prefix': 'ftable'
+    'body': '\\begin{table}\n\t\\begin{tabular}{$1}\n\t\t$2\n\t\\end{tabular}\\caption{$3}\n\t\\label{table:$4}\n\\end{table}'
 
 # Math, taken from  https://github.com/SublimeText/LaTeXTools/blob/master/LaTeX%20math.sublime-completions
   'alpha':


### PR DESCRIPTION
This PR adds two float snippets, one for figures and one for tables. I've added these for my own use but figured they'd be useful to others. I'm not sure how you'd like to differentiate them from the existing "table" and "figure" snippets (which are references). I called them "ffig" and "ftable" for float figure and float table. Happy to change that.