### PR TITLE
Fix display math prefix. Add snippet for math mode.

### DIFF
--- a/snippets/language-latex.cson
+++ b/snippets/language-latex.cson
@@ -66,7 +66,7 @@
     'body': '\\\\[\n\t$1\n\\\\]'
   'Math Mode - $ … $':
     'prefix': 'math'
-    'body': '$$'
+    'body': '$$1$'
 
 # Others
   '\\\\begin{}…\\\\end{}':

--- a/snippets/language-latex.cson
+++ b/snippets/language-latex.cson
@@ -62,8 +62,11 @@
     'prefix': 'table'
     'body': '${1:Table}~\\\\ref{${2:tab:}}$0'
   'Display Math — \\\\[ … \\\\]':
-    'prefix': '$$'
+    'prefix': 'display'
     'body': '\\\\[\n\t$1\n\\\\]'
+  'Math Mode - $ … $':
+    'prefix': 'math'
+    'body': '$$'
 
 # Others
   '\\\\begin{}…\\\\end{}':


### PR DESCRIPTION
I changed the prefix for the Display Math Snippet so that it would trigger properly. I also added a Math Mode Snippet. See area/language-latex#39