### PR TITLE
Fix simple \begin{lstlisting} syntax highlighting

### DIFF
--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -169,7 +169,7 @@
         ]
       }
       {
-        'begin': '((\\\\)begin)(\\{)(lstlisting)(\\})(?:(\\[).*(\\]))?(\\s*%.*\\n?)?'
+        'begin': '(((\\\\)begin)(\\{)(lstlisting)(\\})(?:(\\[).*(\\]))?(\\s*%.*\\n?)?)'
         'captures':
           '1':
             'name': 'meta.function.embedded.latex'


### PR DESCRIPTION
This commit will resolve #41