### PR TITLE
BUG: fix snippets for phi, epsilon, theta

### DIFF
--- a/snippets/language-latex.cson
+++ b/snippets/language-latex.cson
@@ -101,7 +101,7 @@
   'varepsilon':
     'prefix': 'epsilon'
     'body': 'varepsilon'
-  'epsilon':
+  'epsilon2':
     'prefix': 'varepsilon'
     'body': 'epsilon'
   'zeta':
@@ -116,7 +116,7 @@
   'vartheta':
     'prefix': '\\\\theta'
     'body': '\\\\vartheta'
-  'theta':
+  'theta2':
     'prefix': '\\\\vartheta'
     'body': '\\\\theta'
   'iota':
@@ -158,7 +158,7 @@
   'varphi':
     'prefix': '\\\\phi'
     'body': '\\\\varphi'
-  'phi':
+  'phi2':
     'prefix': '\\\\varphi'
     'body': '\\\\phi'
   'chi':


### PR DESCRIPTION
I added a `2` to the name of the snippet that converts from `varNAME` to `NAME`. 

Having it named `NAME` masked the original snippet with the exact same name and made the snippets not work at the original entry point (i.e. `e[TAB]` wasn't inserting `\epsilon` because the snippet named `epsilon` with that prefix was masked by the snippet with the same name and prefix `varepsilon`).