### PR TITLE
reorder keywords in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "engines": {
   "atom": ">0.50.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "keywords": [
+      "latex"
+    ]
 }
-"keywords": [
-    "latex",
-  ],


### PR DESCRIPTION
In atom 1.1 the package cannot be loaded because keywords is incorrectly placed in `package.json`.

The simply reorders it. Here is an example of the error that 1 receives when trying to `apm develop language-latex`

```
0 info it worked if it ends with ok
1 verbose cli [ '/Applications/Atom.app/Contents/Resources/app/apm/bin/node',
1 verbose cli   '/Applications/Atom.app/Contents/Resources/app/apm/node_modules/npm/bin/npm-cli.js',
1 verbose cli   '--globalconfig',
1 verbose cli   '/Users/hjp/.atom/.apm/.apmrc',
1 verbose cli   '--userconfig',
1 verbose cli   '/Users/hjp/.atom/.apmrc',
1 verbose cli   'install',
1 verbose cli   '--target=0.34.0',
1 verbose cli   '--arch=x64' ]
2 info using npm@2.13.3
3 info using node@v0.10.40
4 verbose readDependencies loading dependencies from /Users/hjp/github/language-latex/package.json
5 error install Couldn't read dependencies
6 verbose stack Error: Failed to parse json
6 verbose stack Unexpected token '"' at 13:1
6 verbose stack "keywords": [
6 verbose stack ^
6 verbose stack     at parseError (/Applications/Atom.app/Contents/Resources/app/apm/node_modules/npm/node_modules/read-package-json/read-json.js:379:11)
6 verbose stack     at parseJson (/Applications/Atom.app/Contents/Resources/app/apm/node_modules/npm/node_modules/read-package-json/read-json.js:68:23)
6 verbose stack     at /Applications/Atom.app/Contents/Resources/app/apm/node_modules/npm/node_modules/read-package-json/read-json.js:48:5
6 verbose stack     at evalmachine.<anonymous>:272:14
6 verbose stack     at /Applications/Atom.app/Contents/Resources/app/apm/node_modules/npm/node_modules/read-package-json/node_modules/graceful-fs/graceful-fs.js:102:5
6 verbose stack     at Object.oncomplete (evalmachine.<anonymous>:108:15)
7 verbose cwd /Users/hjp/github/language-latex
8 error Darwin 14.5.0
9 error argv "/Applications/Atom.app/Contents/Resources/app/apm/bin/node" "/Applications/Atom.app/Contents/Resources/app/apm/node_modules/npm/bin/npm-cli.js" "--globalconfig" "/Users/hjp/.atom/.apm/.apmrc" "--userconfig" "/Users/hjp/.atom/.apmrc" "install" "--target=0.34.0" "--arch=x64"
10 error node v0.10.40
11 error npm  v2.13.3
12 error file /Users/hjp/github/language-latex/package.json
13 error code EJSONPARSE
14 error Failed to parse json
14 error Unexpected token '"' at 13:1
14 error "keywords": [
14 error ^
15 error File: /Users/hjp/github/language-latex/package.json
16 error Failed to parse package.json data.
16 error package.json must be actual JSON, not just JavaScript.
16 error
16 error This is not a bug in npm.
16 error Tell the package author to fix their package.json file. JSON.parse
17 verbose exit [ 1, true ]
```