### PR TITLE
Issue #68 - Adding european diacritics to regex for labels

### DIFF
--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -625,7 +625,7 @@
     'name': 'meta.reference.latex'
     'patterns': [
       {
-        'match': '[a-zA-Z0-9\\.,:/*!^_-]'
+        'match': '[a-zA-Z0-9\u00C0-\u017F\\.,:/*!^_-]'
         'name': 'constant.other.reference.latex'
       }
     ]
@@ -646,7 +646,7 @@
     'name': 'meta.definition.latex'
     'patterns': [
       {
-        'match': '[a-zA-Z0-9\\.,:/*!^_-]'
+        'match': '[a-zA-Z0-9\u00C0-\u017F\\.,:/*!^_-]'
         'name': 'variable.parameter.definition.latex'
       }
     ]


### PR DESCRIPTION
Hi, this modification will fix highlighting in labels and references if European diacritics are involved.