### PR TITLE
Added .tikz extension support

### DIFF
--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -1,5 +1,6 @@
 'fileTypes': [
   'tex'
+  'tikz'
 ]
 'firstLineMatch': '^\\\\documentclass(?!.*\\{beamer\\})'
 'name': 'LaTeX'


### PR DESCRIPTION
I always work with both .tex and .tikz extensions in latex, but without this small change I would have to always select the syntax manually for the .tikz files.