### PR TITLE
Added KOMA-Script letter class option to supported file types

### DIFF
--- a/grammars/tex.cson
+++ b/grammars/tex.cson
@@ -3,6 +3,7 @@
   'cls'
   'bbx'
   'cbx'
+  'lco'
 ]
 'name': 'TeX'
 'patterns': [


### PR DESCRIPTION
I Added the lco file type to support KOMA-Scripts letter class option files