### PR TITLE
Throw away grammars about quotation marks

### DIFF
--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -1909,38 +1909,6 @@
     'name': 'meta.function.verb.latex'
   }
   {
-    'begin': '">'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.latex'
-    'end': '"<'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.latex'
-    'name': 'string.quoted.double.guillemot.reversed.latex'
-    'patterns': [
-      {
-        'include': '$base'
-      }
-    ]
-  }
-  {
-    'begin': '"<'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.latex'
-    'end': '">'
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.latex'
-    'name': 'string.quoted.double.guillemot.latex'
-    'patterns': [
-      {
-        'include': '$base'
-      }
-    ]
-  }
-  {
     'begin': '\\\\\\('
     'beginCaptures':
       '0':

--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -1909,54 +1909,6 @@
     'name': 'meta.function.verb.latex'
   }
   {
-    'begin': '"`'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.latex'
-    'end': '"\''
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.latex'
-    'name': 'string.quoted.double.low-high.latex'
-    'patterns': [
-      {
-        'include': '$base'
-      }
-    ]
-  }
-  {
-    'begin': '``'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.latex'
-    'end': '\'\''
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.latex'
-    'name': 'string.quoted.double.latex'
-    'patterns': [
-      {
-        'include': '$base'
-      }
-    ]
-  }
-  {
-    'begin': '`'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.latex'
-    'end': '\''
-    'endCaptures':
-      '0':
-        'name': 'punctuation.definition.string.end.latex'
-    'name': 'string.quoted.single.latex'
-    'patterns': [
-      {
-        'include': '$base'
-      }
-    ]
-  }
-  {
     'begin': '">'
     'beginCaptures':
       '0':


### PR DESCRIPTION
As proposed in #61, we are going to stop highlighting strings inside quotation marks.

Fix #87 and #61.
