### PR TITLE
Fix disabled snippet autocompletions in math mode

### DIFF
--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -1427,7 +1427,7 @@ patterns: [
         name: 'variable.parameter.function.latex'
       5:
         name: 'punctuation.definition.arguments.end.latex'
-    contentName: 'string.other.math.block.environment.latex'
+    contentName: 'markup.other.math.block.environment.latex'
     end: '''(?x)
               (?:\\s*)
               ((\\\\)end)
@@ -1462,7 +1462,7 @@ patterns: [
         name: 'variable.parameter.function.latex'
       8:
         name: 'punctuation.definition.arguments.end.latex'
-    contentName: 'string.other.math.block.environment.latex'
+    contentName: 'markup.other.math.block.environment.latex'
     end: '(?:\\s*)((\\\\)end)(\\{)(\\4)(\\})'
     name: 'meta.function.environment.math.latex'
     patterns: [
@@ -1490,7 +1490,7 @@ patterns: [
         name: 'variable.parameter.latex'
       8:
         name: 'punctuation.definition.arguments.optional.end.latex'
-    contentName: 'string.other.math.block.environment.latex'
+    contentName: 'markup.other.math.block.environment.latex'
     end: '(?:\\s*)((\\\\)end)(\\{)(\\4)(\\})'
     name: 'meta.function.environment.math.latex'
     patterns: [
@@ -1512,7 +1512,7 @@ patterns: [
         name: 'invalid.deprecated.environment.eqnarray.latex'
       5:
         name: 'punctuation.definition.arguments.end.latex'
-    contentName: 'string.other.math.block.environment.latex'
+    contentName: 'markup.other.math.block.environment.latex'
     end: '(?:\\s*)((\\\\)end)(\\{)(\\4)(\\})'
     name: 'meta.function.environment.math.latex'
     patterns: [
@@ -1955,12 +1955,12 @@ patterns: [
     begin: '\\\\\\('
     beginCaptures:
       0:
-        name: 'punctuation.definition.string.begin.latex'
+        name: 'punctuation.definition.markup.begin.latex'
     end: '\\\\\\)'
     endCaptures:
       0:
-        name: 'punctuation.definition.string.end.latex'
-    name: 'string.other.math.latex'
+        name: 'punctuation.definition.markup.end.latex'
+    name: 'markup.other.math.inline.latex'
     patterns: [
       {
         include: '$base'
@@ -1971,12 +1971,12 @@ patterns: [
     begin: '\\\\\\['
     beginCaptures:
       0:
-        name: 'punctuation.definition.string.begin.latex'
+        name: 'punctuation.definition.markup.begin.latex'
     end: '\\\\\\]'
     endCaptures:
       0:
-        name: 'punctuation.definition.string.end.latex'
-    name: 'string.other.math.latex'
+        name: 'punctuation.definition.markup.end.latex'
+    name: 'markup.other.math.display.latex'
     patterns: [
       {
         include: '$base'

--- a/grammars/tex.cson
+++ b/grammars/tex.cson
@@ -91,12 +91,12 @@ patterns: [
     begin: '\\$\\$'
     beginCaptures:
       0:
-        name: 'punctuation.definition.string.begin.tex'
+        name: 'punctuation.definition.markup.begin.tex'
     end: '\\$\\$'
     endCaptures:
       0:
-        name: 'punctuation.definition.string.end.tex'
-    name: 'string.other.math.block.tex'
+        name: 'punctuation.definition.markup.end.tex'
+    name: 'markup.other.math.display.tex'
     patterns: [
       {
         include: '#math'
@@ -114,12 +114,12 @@ patterns: [
     begin: '\\$'
     beginCaptures:
       0:
-        name: 'punctuation.definition.string.begin.tex'
+        name: 'punctuation.definition.markup.begin.tex'
     end: '\\$'
     endCaptures:
       0:
-        name: 'punctuation.definition.string.end.tex'
-    name: 'string.other.math.tex'
+        name: 'punctuation.definition.markup.end.tex'
+    name: 'markup.other.math.inline.tex'
     patterns: [
       {
         match: '\\\\\\$'

--- a/snippets/language-latex.cson
+++ b/snippets/language-latex.cson
@@ -68,7 +68,7 @@
     'body': '$$1$$0'
 
 # math, taken from  https://github.com/SublimeText/LaTeXTools/blob/master/LaTeX%20math.sublime-completions
-'.text.tex.latex .string.other.math':
+'.text.tex.latex .markup.other.math':
   'math italic':
     'prefix': 'it'
     'body': '\\\\mathit{$1}$0'


### PR DESCRIPTION
[As you can see](https://github.com/atom/autocomplete-snippets/blob/v1.11.0/lib/snippets-provider.coffee#L4), snippet autocompletion is currently disabled in `string` scope. Since math mode in this package is scope as `.string.other.math`, [math snippets](https://github.com/area/language-latex/blob/v1.1.0/snippets/language-latex.cson#L71) cannot be autocompleted (note that snippet expansion itself works).

While atom/autocomplete-snippets#77 is trying to make it configurable, I am feeling that scoping math stuff as `.string` is a bad idea in the first place; it isn't string. Instead of `.string`, `.markup` sounds more suitable to me, and by re-scoping math stuff as `.markup` math snippet autocompletion will be available again.

Fix #120.