### PR TITLE
Add support for embedded code into GFM

### DIFF
--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -6,6 +6,7 @@
 ]
 'limitLineLength': false
 'firstLineMatch': '^\\\\documentclass(?!.*\\{beamer\\})'
+'injectionSelector': 'source.embedded.latex'
 'patterns': [
   {
     'match': '(?=\\s)(?<=\\\\[\\w@]|\\\\[\\w@]{2}|\\\\[\\w@]{3}|\\\\[\\w@]{4}|\\\\[\\w@]{5}|\\\\[\\w@]{6})\\s'


### PR DESCRIPTION
Since v0.90.0 of `language-gfm` is shipped with [a stable release of Atom](https://github.com/atom/atom/releases/tag/v1.20.0), we can now utilize the embed feature in atom/language-gfm#175.