### PR TITLE
Move LaTeX-only extensions to LaTeX's fileTypes

### DIFF
--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -1,6 +1,11 @@
 'scopeName': 'text.tex.latex'
 'name': 'LaTeX'
 'fileTypes': [
+  'bbx'
+  'cbx'
+  'cls'
+  'lco'
+  'sty'
   'tex'
   'tikz'
 ]

--- a/grammars/tex.cson
+++ b/grammars/tex.cson
@@ -1,13 +1,8 @@
 'scopeName': 'text.tex'
 'name': 'TeX'
 'fileTypes': [
-  'sty'
-  'cls'
   'dtx'
   'ins'
-  'bbx'
-  'cbx'
-  'lco'
 ]
 'patterns': [
   {


### PR DESCRIPTION
The following extensions are based on LaTeX and its packages with a very few exception. So they should be scoped as LaTeX.

- `*.cls` and `*.sty`: LaTeX's document class and package
- `*.bbx` and `*.cbx`: Biblatex's bibliography and citation style
- `*.lco`: KOMA-script's letter class option 