### PR TITLE
Add comment env support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ based on http://keepachangelog.com/en/1.0.0/
 ### Added
 - Basic spec for the LaTeX grammar.
 - Grammar for `gls` and `glstext` like commands.
+- Grammar for `comment` environment.
 
 ### Changed
 - Set 'softWrap' to be true by default in LaTeX files.

--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -1640,6 +1640,23 @@
     ]
   }
   {
+    'begin': '(?:\\s*)((\\\\)begin)(\\{)(comment)(\\})'
+    'captures':
+      '1':
+        'name': 'support.function.be.latex'
+      '2':
+        'name': 'punctuation.definition.function.latex'
+      '3':
+        'name': 'punctuation.definition.arguments.latex'
+      '4':
+        'name': 'variable.parameter.function.latex'
+      '5':
+        'name': 'punctuation.definition.arguments.latex'
+    'end': '((\\\\)end)(\\{)(\\4)(\\})(?:\\s*\\n)?'
+    'name': 'meta.function.environment.comment.latex'
+    'contentName': 'comment.block.latex'
+  }
+  {
     'begin': '(?:\\s*)((\\\\)begin)(\\{)(\\w+[*]?)(\\})'
     'captures':
       '1':


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to this repository!

Before you submit, please make sure you fill out the sections below and update the CHANGELOG.md file.
-->

### Description of the Change
<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
Adds support for the `comment` environment.


### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
The current design is based almost entirely off the generic environment pattern, just made specific to comments.

The interior scope is consistent with the [textmate manual](https://manual.macromates.com/en/language_grammars), as it specifies `comment.block` as a possible scope.

### Benefits
<!-- What benefits will be realized by the code change? -->
The fairly common (and unambiguous) `comment` environment will have it's contents correctly scoped as comments, ensuring they appear consistent with other comments and the contents do not interfere with other syntax highlighting.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the code change? -->
I am getting a bug due to `'name': 'meta.function.environment.comment.latex'` where the begin and end commands are shown as italic (when using a theme that puts comments in italics; tested with `one dark` and `solarized dark`). This is specifically caused by the `comment` term, and removing it or changing it fixes the issue.

However, this should be a syntax package issue and is not our concern. The pattern should remain with the `meta` scope, to keep it consistent with other environment patterns.

### Applicable Issues
<!-- Enter any applicable Issues here -->
#165 