### PR TITLE
Fix disabled snippet autocompletions in math mode

### DIFF
--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -1430,7 +1430,7 @@
         'name': 'variable.parameter.function.latex'
       '5':
         'name': 'punctuation.definition.arguments.end.latex'
-    'contentName': 'string.other.math.block.environment.latex'
+    'contentName': 'markup.other.math.block.environment.latex'
     'end': '''(?x)
               (?:\\s*)
               ((\\\\)end)
@@ -1465,7 +1465,7 @@
         'name': 'variable.parameter.function.latex'
       '8':
         'name': 'punctuation.definition.arguments.end.latex'
-    'contentName': 'string.other.math.block.environment.latex'
+    'contentName': 'markup.other.math.block.environment.latex'
     'end': '(?:\\s*)((\\\\)end)(\\{)(\\4)(\\})'
     'name': 'meta.function.environment.math.latex'
     'patterns': [
@@ -1493,7 +1493,7 @@
         'name': 'variable.parameter.latex'
       '8':
         'name': 'punctuation.definition.arguments.optional.end.latex'
-    'contentName': 'string.other.math.block.environment.latex'
+    'contentName': 'markup.other.math.block.environment.latex'
     'end': '(?:\\s*)((\\\\)end)(\\{)(\\4)(\\})'
     'name': 'meta.function.environment.math.latex'
     'patterns': [
@@ -1515,7 +1515,7 @@
         'name': 'invalid.deprecated.environment.eqnarray.latex'
       '5':
         'name': 'punctuation.definition.arguments.end.latex'
-    'contentName': 'string.other.math.block.environment.latex'
+    'contentName': 'markup.other.math.block.environment.latex'
     'end': '(?:\\s*)((\\\\)end)(\\{)(\\4)(\\})'
     'name': 'meta.function.environment.math.latex'
     'patterns': [
@@ -1958,12 +1958,12 @@
     'begin': '\\\\\\('
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.latex'
+        'name': 'punctuation.definition.markup.begin.latex'
     'end': '\\\\\\)'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.latex'
-    'name': 'string.other.math.latex'
+    'name': 'markup.other.math.inline.latex'
     'patterns': [
       {
         'include': '$base'
@@ -1974,12 +1974,12 @@
     'begin': '\\\\\\['
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.latex'
+        'name': 'punctuation.definition.markup.begin.latex'
     'end': '\\\\\\]'
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.latex'
-    'name': 'string.other.math.latex'
+    'name': 'markup.other.math.display.latex'
     'patterns': [
       {
         'include': '$base'

--- a/grammars/tex.cson
+++ b/grammars/tex.cson
@@ -91,12 +91,12 @@
     'begin': '\\$\\$'
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.tex'
+        'name': 'punctuation.definition.markup.begin.tex'
     'end': '\\$\\$'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.string.end.tex'
-    'name': 'string.other.math.block.tex'
+        'name': 'punctuation.definition.markup.end.tex'
+    'name': 'markup.other.math.display.tex'
     'patterns': [
       {
         'include': '#math'
@@ -114,12 +114,12 @@
     'begin': '\\$'
     'beginCaptures':
       '0':
-        'name': 'punctuation.definition.string.begin.tex'
+        'name': 'punctuation.definition.markup.begin.tex'
     'end': '\\$'
     'endCaptures':
       '0':
-        'name': 'punctuation.definition.string.end.tex'
-    'name': 'string.other.math.tex'
+        'name': 'punctuation.definition.markup.end.tex'
+    'name': 'markup.other.math.inline.tex'
     'patterns': [
       {
         'match': '\\\\\\$'

--- a/snippets/language-latex.cson
+++ b/snippets/language-latex.cson
@@ -68,7 +68,7 @@
     'body': '$$1$$0'
 
 # math, taken from  https://github.com/SublimeText/LaTeXTools/blob/master/LaTeX%20math.sublime-completions
-'.text.tex.latex .string.other.math':
+'.text.tex.latex .markup.other.math':
   'math italic':
     'prefix': 'it'
     'body': '\\\\mathit{$1}$0'


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to this repository!

Before you submit, please make sure you fill out the sections below and update the CHANGELOG.md file.
-->

### Description of the Change
<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->
Refer to #137 to see what this change brings.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->
None, I guess.

### Benefits
<!-- What benefits will be realized by the code change? -->
Snippet autocompletion in math mode will work.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the code change? -->
This will break backward compatibility for users who defines snippets in their personal configuration, and therefore needs to be released as version 2.

### Applicable Issues
<!-- Enter any applicable Issues here -->
Fix #120.