### PR TITLE
Added support for all natbib and BibLaTeX citation commands

### DIFF
--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -1845,7 +1845,7 @@
   }
   {
     'begin': '''(?x)
-                ((\\\\)(?:text)?(?:paren)?(?:auto)?(?:foot)?(?:full)?(?:no)?(?:short)?[cC]ites?(?:al)?(?:t|p|author|year(?:par)?|title)?[ANP]*\\*?)
+                ((\\\\)(?:(?:[tT]ext|[pP]aren|[aA]uto|[sS]mart|super|foot)?(?:full|no|short|(?:[vV]|[pP]|[fF]t?|[sS]|[tT]|[aA])?[vV]ol|(?:[pP]|f)?[nN]ote|short)?[cC]ites?(?:al)?(?:t|p|num|author|name|list|field|url|date|year(?:par)?|title)?(?:texts?)?|(?:paren|bracket)texts?)[ANP]*\\*?)
                 (?:(\\[)[^\\]]*(\\]))?
                 (?:(\\[)[^\\]]*(\\]))?
                 (\\{)


### PR DESCRIPTION
Modified the Regex for citation syntax, now it is able to capture all natbib commands and biblatex commands for citations.

**natbib commands list**
    from https://gking.harvard.edu/files/natnotes2.pdf
**biblatex commands list**
    from http://mirrors.ibiblio.org/CTAN/macros/latex/contrib/biblatex/doc/biblatex.pdf

Citations commands that wasn't capturing before includes:

```latex
%==========================================================%
%|                     Natbib Commands                    |%
%==========================================================%
\citenum{foo_bar}
\citetext{foo_bar}

%==========================================================%
%|                    BibLaTeX Commands                    |%
%==========================================================%
% Standard Commands
\Parencite{foo_bar}
\footcitetext{foo_bar}

% Style-specific Commands
\smartcite{foo_bar}
\Smartcite{foo_bar}
\supercite{foo_bar}

% Qualified Citation Lists

\Parencites{foo_bar}
\footcitetexts{foo_bar}
\smartcites{foo_bar}
\Smartcites{foo_bar}
\Textcite{aabide}
\supercites{aabide}

% Style-independent Commands
\Autocite{foo_bar}
\Autocite*{foo_bar}
\Autocites{foo_bar}
\citedate{foo_bar}
\citedate*{foo_bar}
\citeurl{foo_bar}
\parentext{foo_bar}
\brackettext{foo_bar}

% Special Commands
\volcite[hprenotei]{hvolumei}[hpagei]{foo_bar}
\Volcite[hprenotei]{hvolumei}[hpagei]{foo_bar}
\volcites[hprenotei]{hvolumei}[hpagei]{foo_bar}
\Volcites[hprenotei]{hvolumei}[hpagei]{foo_bar}
\pvolcite[hprenotei]{hvolumei}[hpagei]{foo_bar}
\Pvolcite[hprenotei]{hvolumei}[hpagei]{foo_bar}
\pvolcites[hprenotei]{hvolumei}[hpagei]{foo_bar}[hprenotei]{hvolumei}
          [hpagei]{foo_bar}
\Pvolcites[hprenotei]{hvolumei}
\fvolcite[hprenotei]{hvolumei}[hpagei]{foo_bar}
\ftvolcite[hprenotei]{hvolumei}[hpagei]{foo_bar}
\fvolcites[hprenotei]{hvolumei}[hpagei]{foo_bar}[hprenotei]{hvolumei}
          [hpagei]{foo_bar}
\Fvolcites[hprenotei]{hvolumei}[hpagei]{foo_bar}[hprenotei]{hvolumei}
          [hpagei]{foo_bar}
\svolcite[hprenotei]{hvolumei}[hpagei]{foo_bar}
\Svolcite[hprenotei]{hvolumei}[hpagei]{foo_bar}
\svolcites[hprenotei]{hvolumei}[hpagei]{foo_bar}[hprenotei]{hvolumei}
          [hpagei]{foo_bar}
\Svolcites[hprenotei]{hvolumei}[hpagei]{foo_bar}[hprenotei]{hvolumei}
          [hpagei]{foo_bar}
\tvolcite[hprenotei]{hvolumei}[hpagei]{foo_bar}
\Tvolcite[hprenotei]{hvolumei}[hpagei]{foo_bar}
\tvolcites[hprenotei]{hvolumei}[hpagei]{foo_bar}[hprenotei]{hvolumei}
          [hpagei]{foo_bar}
\Tvolcites[hprenotei]{hvolumei}[hpagei]{foo_bar}[hprenotei]{hvolumei}
          [hpagei]{foo_bar}
\avolcite[hprenotei]{hvolumei}[hpagei]{foo_bar}
\Avolcite[hprenotei]{hvolumei}[hpagei]{foo_bar}
\avolcites[hprenotei]{hvolumei}[hpagei]{foo_bar}[hprenotei]{hvolumei}
          [hpagei]{foo_bar}
\Avolcites[hprenotei]{hvolumei}[hpagei]{foo_bar}[hprenotei]{hvolumei}
          [hpagei]{foo_bar}
\notecite{foo_bar}
\Notecite{foo_bar}
\pnotecite{foo_bar}
\Pnotecite{foo_bar}
\fnotecite{foo_bar}

% Low-level Commands
\citename{foo_bar}[hformati]{hname listi}
\citelist{foo_bar}[hformati]{hliteral listi}
\citefield{foo_bar}[hformati]{hfieldi}
```