### PR TITLE
Change `$base` to `$self`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ based on http://keepachangelog.com/en/1.0.0/
 - Grammar for `comment` environment.
 
 ### Changed
+- Changed `'include': '$base'` to `'include': '$self'`. This improves highlighting when embedded in another grammar, such as Markdown.
 - Set 'softWrap' to be true by default in LaTeX files.
 - Changed inline math snippet from `$...$` to `\(...\)`.
 

--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -2055,6 +2055,22 @@
     'name': 'meta.column-specials.latex'
   }
   {
+    'begin': '\\{'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.section.group.begin.tex.latex'
+    'end': '\\}'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.section.group.end.tex.latex'
+    'name': 'meta.group.braces.tex.latex'
+    'patterns': [
+      {
+        'include': '$self'
+      }
+    ]
+  }
+  {
     'include': 'text.tex'
   }
 ]

--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -122,7 +122,7 @@
         'name': 'support.variable.expl3.latex'
       }
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -147,7 +147,7 @@
         'name': 'support.variable.expl3.latex'
       }
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -1448,7 +1448,7 @@
     'name': 'meta.function.environment.math.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -1476,7 +1476,7 @@
     'name': 'meta.function.environment.math.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -1504,7 +1504,7 @@
     'name': 'meta.function.environment.math.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -1526,7 +1526,7 @@
     'name': 'meta.function.environment.math.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -1580,17 +1580,17 @@
             'name': 'meta.cell.environment.tabular.latex'
             'patterns': [
               {
-                'include': '$base'
+                'include': '$self'
               }
             ]
           }
           {
-            'include': '$base'
+            'include': '$self'
           }
         ]
       }
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -1611,7 +1611,7 @@
     'name': 'meta.function.environment.list.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -1673,7 +1673,7 @@
     'name': 'meta.function.environment.general.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -1712,7 +1712,7 @@
         'name': 'punctuation.definition.marginpar.end.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -1745,7 +1745,7 @@
         'name': 'punctuation.definition.footnote.end.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -1766,7 +1766,7 @@
     'name': 'meta.function.emph.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -1788,7 +1788,7 @@
     'name': 'meta.function.textit.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -1809,7 +1809,7 @@
     'name': 'meta.function.textbf.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -1830,7 +1830,7 @@
     'name': 'meta.function.texttt.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -2018,7 +2018,7 @@
     'name': 'string.other.math.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }
@@ -2034,7 +2034,7 @@
     'name': 'string.other.math.latex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }

--- a/grammars/tex.cson
+++ b/grammars/tex.cson
@@ -82,7 +82,7 @@
     'name': 'meta.group.braces.tex'
     'patterns': [
       {
-        'include': '$base'
+        'include': '$self'
       }
     ]
   }


### PR DESCRIPTION
The use of `'include': '$base'` causes LaTeX syntax highlighting to not
work correctly when embedded in another grammar. The short summary of the difference between them, from [here](https://gist.github.com/Aerijo/b8c82d647db783187804e86fa0a604a1#complex-multiline-rule), is:

>  `$self` points to the grammar `$self` appears in (points to _itself_), whereas `$base` points to the _base_ language of the file, which could be anything.

This means that when `language-latex` is embedded within `language-markdown`, every time an `'include': '$base'` occurs, Markdown highlighting is included instead of LaTeX highlighting. [Ugliness ensues](https://github.com/burodepeper/language-markdown/pull/226#issuecomment-401840841).

### Description of the Change

All occurrences of 
```cson
'include': '$base'
```
were replaced with
```cson
'include': '$self'
```

### Alternate Designs

There is no other way to prevent any incorrect highlighting from the `$base` file. A compromise that could theoretically work, but does not in practice is using
```cson
{
  'include': '$self'
}
{
  'include': '$base'
}
```

This does not work for this situation because Markdown highlighting is still injected where there should only be LaTeX highlighting. In this example, the HTML injections (part of Markdown syntax) causes the entire rest of the document to be miscolored:
![image](https://user-images.githubusercontent.com/15164633/42174777-656bfd82-7df1-11e8-9ed3-03bc49a7bf37.png)


### Benefits

Accurate syntax highlighting for grammars that embed LaTeX. I think this is primarily Markdown, however due to the popularity of Pandoc and programs that use it, such as Knitr/R Markdown, this is an important change that would improve a lot of syntax highlighting for math and tables.


### Possible Drawbacks

The use of `$self` instead of `$base` means that recursive includes happen only within the scope of the inner file, and do not include the rules within the top-level grammar that is embedding the inner file. However with a few included changes, there should be **no drawbacks**.

Currently, `text.tex.latex.beamer` and `text.tex.latex.memoir` include `text.tex.latex`, and `text.tex.latex` includes `text.tex`.

#### Including of `text.tex`

`text.tex` only uses `$base` once. That is for anything within arbitrary `{ ... }` blocks. 
https://github.com/area/language-latex/blob/2447b74978e2584e610e14d956c1c41cc1b8c7ab/grammars/tex.cson#L73-L88

In order to fix this, I add that rule to the end of `text.tex.latex` and change both to `include: '$self'`. This should give near-identical highlighting as now. (I could also include this rule for `text.tex.latex.beamer` and `text.tex.latex.memoir`, but this seems unnecessary as those provide few extra rules and are unlikely to be nested within arbitrary `{` `}` blocks.)

#### Including of `text.tex.latex`

The only other side-effects to watch out for are `text.tex.latex.beamer` and `text.tex.latex.memoir` including `text.tex.latex`. However these side-effects seem rare if not impossible. The extra rules provided within `text.tex.latex.beamer` and `text.tex.latex.memoir` seem top-level only, and they would not be used within any of the environments in `text.tex.latex` that currently employ `$base`. 

For example, you would not have
`````latex
\begin{equation}
\begin{frame}
\end{frame}
\end{equation}
`````

This means that it's fine to have `include: $self` and not `include: $base` in each of these `text.tex.latex` environments, because they would not need any special rules from the `text.tex.latex.memoir` or `text.tex.latex.beamer` grammars.

### Applicable Issues

https://github.com/burodepeper/language-markdown/pull/226