### PR TITLE
Add tree-sitter-biber support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/grammars/bibtex.cson
+++ b/grammars/bibtex.cson
@@ -23,7 +23,7 @@
       '3':
         'name': 'punctuation.section.string-constant.begin.bibtex'
       '4':
-        'name': 'variable.other.bibtex'
+        'name': '.bibtex'
     'end': '\\}'
     'endCaptures':
       '0':

--- a/grammars/bibtex.cson
+++ b/grammars/bibtex.cson
@@ -23,7 +23,7 @@
       '3':
         'name': 'punctuation.section.string-constant.begin.bibtex'
       '4':
-        'name': '.bibtex'
+        'name': 'variable.other.bibtex'
     'end': '\\}'
     'endCaptures':
       '0':

--- a/grammars/tree-sitter-biber.cson
+++ b/grammars/tree-sitter-biber.cson
@@ -10,10 +10,15 @@ parser: 'tree-sitter-biber'
 
 folds: [
   {
-    type: 'comment'
+    type: ['entry', 'preamble_command', 'string_command', 'comment_command']
+    start: {index: 0}
+    end: {index: -1}
   }
   {
     type: 'junk'
+  }
+  {
+    type: 'comment' # Has no effect currently
   }
 ]
 

--- a/grammars/tree-sitter-biber.cson
+++ b/grammars/tree-sitter-biber.cson
@@ -27,28 +27,29 @@ scopes:
   'comment': 'comment.line.percentage'
 
   'comment_command': 'comment.block'
-  'preamble_command > "@"': 'punctuation.definition.keyword.comment'
-  'preamble_command > name': 'keyword.other.comment'
+  'comment_command > "@"': 'keyword.other.comment, punctuation.definition.keyword.comment'
+  'comment_command > name': 'keyword.other.comment'
 
   'preamble_command': 'meta.preamble'
-  'preamble_command > "@"': 'punctuation.definition.keyword.preamble'
+  'preamble_command > "@"': 'keyword.other.preamble, punctuation.definition.keyword.preamble'
   'preamble_command > name': 'keyword.other.preamble'
   'preamble_command > "{", preamble_command > "("': 'punctuation.section.preamble.begin'
   'preamble_command > "}", preamble_command > ")"': 'punctuation.section.preamble.end'
 
   'string_command': 'meta.string-constant'
-  'string_command > "@"': 'punctuation.definition.keyword.string-constant'
+  'string_command > "@"': 'keyword.other.string-constant, punctuation.definition.keyword.string-constant'
   'string_command > name': 'keyword.other.string-constant'
   'string_command > "{", string_command > "("': 'punctuation.section.string-constant.begin'
   'string_command > "}", string_command > ")"': 'punctuation.section.string-constant.end'
   'string_command > identifier': 'variable.other.key'
 
   'entry': 'meta.entry'
-  'entry > "@"': 'punctuation.definition.keyword.entry'
+  'entry > "@"': 'keyword.other.entry-type, punctuation.definition.keyword.entry'
   'entry > name': 'keyword.other.entry-type'
   'entry > "{", entry > "("': 'punctuation.section.entry.begin'
   'entry > "}", entry > ")"': 'punctuation.section.entry.end'
   'entry > key': 'entity.name.type.entry-key'
+  'entry > ","': 'punctuation.separator.field'
 
   'field': 'meta.field'
   'field > identifier': 'variable.other.key'
@@ -67,5 +68,8 @@ scopes:
       scopes: 'string.braced'
     }
   ]
+  'string > "{", string > "("': 'punctuation.definition.string.start'
+  'string > "}", string > ")"': 'punctuation.definition.string.end'
+  'string > \'"\'': 'punctuation.definition.string.quote' # TODO: Distinguish start and end quote
 
   'integer': 'constant.numeric'

--- a/grammars/tree-sitter-biber.cson
+++ b/grammars/tree-sitter-biber.cson
@@ -1,0 +1,76 @@
+legacyScopeName: 'text.tex.biber'  # API changed; this is no longer needed
+scopeName: 'text.tex.biber'
+
+fileTypes: ['bib']
+
+id: 'biber' # API changed; this is no longer needed
+
+name: 'Biber'
+
+type: 'tree-sitter'
+
+parser: 'tree-sitter-biber'
+
+folds: [
+  {
+    type: 'comment'
+  }
+  {
+    type: 'junk'
+  }
+]
+
+comments:
+  start: '% '
+
+scopes:
+  'program': 'text.tex.biber'
+  'junk': 'comment.line.character.junk'
+  'comment': 'comment.line.percentage'
+
+  'comment_command': 'comment.block'
+
+  'preamble_command': 'meta.preamble'
+  'preamble_command > name': 'keyword.other.preamble' # TODO: Add this to tree-sitter-biber
+  'string_command > "{"': 'punctuation.section.preamble.begin'
+  'string_command > "("': 'punctuation.section.preamble.begin'
+  'string_command > "}"': 'punctuation.section.preamble.end'
+  'string_command > ")"': 'punctuation.section.preamble.end'
+
+  'string_command': 'meta.string-constant'
+  'string_command > "@"': 'punctuation.definition.keyword'
+  'string_command > name': 'keyword.other.string-constant' # TODO: Add this to tree-sitter-biber
+  'string_command > "{"': 'punctuation.section.string-constant.begin'
+  'string_command > "("': 'punctuation.section.string-constant.begin'
+  'string_command > "}"': 'punctuation.section.string-constant.end'
+  'string_command > ")"': 'punctuation.section.string-constant.end'
+  'string_command > identifier': 'variable.other.key'
+
+  'entry': 'meta.entry'
+  'entry > "@"': 'punctuation.definition.keyword'
+  'entry > name': 'keyword.other.entry-type'
+  'entry > "{"': 'punctuation.section.entry.begin'
+  'entry > "("': 'punctuation.section.entry.begin'
+  'entry > "}"': 'punctuation.section.entry.end'
+  'entry > ")"': 'punctuation.section.entry.end'
+  'entry > key': 'entity.name.type.entry-key'
+
+  'field': 'meta.field'
+  'field > identifier': 'variable.other.key'
+  'field > "="': 'punctuation.separator.key-value'
+
+  'value > "#"': 'punctuation.concat'
+
+  'identifier': 'string.interpolated'
+  'string': [
+    {
+      match: '^"'
+      scopes: 'string.quoted.double'
+    }
+    {
+      match: '^{'
+      scopes: 'string.braced'
+    }
+  ]
+
+  'nonnegative_integer': 'constant.numeric'

--- a/grammars/tree-sitter-biber.cson
+++ b/grammars/tree-sitter-biber.cson
@@ -1,9 +1,6 @@
-legacyScopeName: 'text.tex.biber'  # API changed; this is no longer needed
 scopeName: 'text.tex.biber'
 
 fileTypes: ['bib']
-
-id: 'biber' # API changed; this is no longer needed
 
 name: 'Biber'
 
@@ -25,34 +22,32 @@ comments:
 
 scopes:
   'program': 'text.tex.biber'
+
   'junk': 'comment.line.character.junk'
   'comment': 'comment.line.percentage'
 
   'comment_command': 'comment.block'
+  'preamble_command > "@"': 'punctuation.definition.keyword.comment'
+  'preamble_command > name': 'keyword.other.comment'
 
   'preamble_command': 'meta.preamble'
-  'preamble_command > name': 'keyword.other.preamble' # TODO: Add this to tree-sitter-biber
-  'string_command > "{"': 'punctuation.section.preamble.begin'
-  'string_command > "("': 'punctuation.section.preamble.begin'
-  'string_command > "}"': 'punctuation.section.preamble.end'
-  'string_command > ")"': 'punctuation.section.preamble.end'
+  'preamble_command > "@"': 'punctuation.definition.keyword.preamble'
+  'preamble_command > name': 'keyword.other.preamble'
+  'preamble_command > "{", preamble_command > "("': 'punctuation.section.preamble.begin'
+  'preamble_command > "}", preamble_command > ")"': 'punctuation.section.preamble.end'
 
   'string_command': 'meta.string-constant'
-  'string_command > "@"': 'punctuation.definition.keyword'
-  'string_command > name': 'keyword.other.string-constant' # TODO: Add this to tree-sitter-biber
-  'string_command > "{"': 'punctuation.section.string-constant.begin'
-  'string_command > "("': 'punctuation.section.string-constant.begin'
-  'string_command > "}"': 'punctuation.section.string-constant.end'
-  'string_command > ")"': 'punctuation.section.string-constant.end'
+  'string_command > "@"': 'punctuation.definition.keyword.string-constant'
+  'string_command > name': 'keyword.other.string-constant'
+  'string_command > "{", string_command > "("': 'punctuation.section.string-constant.begin'
+  'string_command > "}", string_command > ")"': 'punctuation.section.string-constant.end'
   'string_command > identifier': 'variable.other.key'
 
   'entry': 'meta.entry'
-  'entry > "@"': 'punctuation.definition.keyword'
+  'entry > "@"': 'punctuation.definition.keyword.entry'
   'entry > name': 'keyword.other.entry-type'
-  'entry > "{"': 'punctuation.section.entry.begin'
-  'entry > "("': 'punctuation.section.entry.begin'
-  'entry > "}"': 'punctuation.section.entry.end'
-  'entry > ")"': 'punctuation.section.entry.end'
+  'entry > "{", entry > "("': 'punctuation.section.entry.begin'
+  'entry > "}", entry > ")"': 'punctuation.section.entry.end'
   'entry > key': 'entity.name.type.entry-key'
 
   'field': 'meta.field'
@@ -73,4 +68,4 @@ scopes:
     }
   ]
 
-  'nonnegative_integer': 'constant.numeric'
+  'integer': 'constant.numeric'

--- a/grammars/tree-sitter-biber.cson
+++ b/grammars/tree-sitter-biber.cson
@@ -27,8 +27,6 @@ scopes:
   'comment': 'comment.line.percentage'
 
   'comment_command': 'comment.block'
-  'comment_command > "@"': 'keyword.other.comment, punctuation.definition.keyword.comment'
-  'comment_command > name': 'keyword.other.comment'
 
   'preamble_command': 'meta.preamble'
   'preamble_command > "@"': 'keyword.other.preamble, punctuation.definition.keyword.preamble'
@@ -68,8 +66,11 @@ scopes:
       scopes: 'string.braced'
     }
   ]
-  'string > "{", string > "("': 'punctuation.definition.string.start'
+  'string > "{", string > "("': 'punctuation.definition.string.begin'
   'string > "}", string > ")"': 'punctuation.definition.string.end'
   'string > \'"\'': 'punctuation.definition.string.quote' # TODO: Distinguish start and end quote
+
+  '"{"': 'punctuation.definition.group.begin'
+  '"}"': 'punctuation.definition.group.end'
 
   'integer': 'constant.numeric'

--- a/grammars/tree-sitter-biber.cson
+++ b/grammars/tree-sitter-biber.cson
@@ -68,7 +68,8 @@ scopes:
   ]
   'string > "{", string > "("': 'punctuation.definition.string.begin'
   'string > "}", string > ")"': 'punctuation.definition.string.end'
-  'string > \'"\'': 'punctuation.definition.string.quote' # TODO: Distinguish start and end quote
+  'string > \'"\':nth-child(0)': 'punctuation.definition.string.begin'
+  'string > \'"\'': 'punctuation.definition.string.end'
 
   '"{"': 'punctuation.definition.group.begin'
   '"}"': 'punctuation.definition.group.end'

--- a/grammars/tree-sitter-biber.cson
+++ b/grammars/tree-sitter-biber.cson
@@ -15,6 +15,11 @@ folds: [
     end: {index: -1}
   }
   {
+    type: 'string'
+    start: {index: 0}
+    end: {index: -1}
+  }
+  {
     type: 'junk'
   }
   {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "tree-sitter-biber": "0.3.5"
+    "tree-sitter-biber": "0.4.0"
   },
   "keywords": [
     "latex"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tree-sitter-biber": "0.3.5"
+  },
   "keywords": [
     "latex"
   ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "language-latex",
   "version": "1.2.0",
-  "private": true,
   "description": "Syntax highlighting for LaTeX for Atom",
   "repository": "https://github.com/area/language-latex",
   "license": "MIT",

--- a/settings/language-latex.cson
+++ b/settings/language-latex.cson
@@ -5,6 +5,7 @@
 '.text.bibtex':
   'editor':
     'foldEndPattern': '^\\s*[)}]\\s*$'
+    'commentStart': '% '
 '.text.tex.latex':
   'editor':
     'increaseIndentPattern': '^\\s*\\\\begin\\{(?!document).*\\}'


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to this repository!

Before you submit, please make sure you fill out the sections below and update the CHANGELOG.md file.
-->

### Description of the Change
<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->

This PR adds `tree-sitter-biber` as a grammar for `.bib` files.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

I also have `tree-sitter-bibtex`, which has slightly different behaviour. However, I expect most people will be using biber syntax, even if they don't know it.

### Benefits
<!-- What benefits will be realized by the code change? -->

Proper syntax tree & no more guess work. Of all languages, biber / bibtex are some of the most simple to parse.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the code change? -->

Originally, users would need to build the parser themselves. I've now set up CI deployment, so the version in use here is already prebuilt for most operating systems. The user does not need to do anything; the installation process will grab the prebuilt binaries itself.

Also, some scopes have changed. I think this is for the best, but it does mean this is a v2.0 release. I also need to iron out a few details on the tree-sitter-biber end.

### Applicable Issues
<!-- Enter any applicable Issues here -->
Closes #184
