### PR TITLE
Adds (back?) auto Beamer detection

### DIFF
--- a/grammars/latex-beamer.cson
+++ b/grammars/latex-beamer.cson
@@ -1,7 +1,7 @@
 'scopeName': 'text.tex.latex.beamer'
 'name': 'LaTeX Beamer'
 'fileTypes': []
-'firstLineMatch': '^\\\\documentclass(\\[.*\\])?\\{beamer\\}'
+'contentRegex': '^\\\\documentclass(\\[.*\\])?\\{beamer\\}'
 'patterns': [
   {
     'begin': '(\\\\use(?:color|font|inner|outer)?theme)(?:(\\[)([^\\]]*)(\\]))?(\\{)'

--- a/grammars/latex-beamer.cson
+++ b/grammars/latex-beamer.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.tex.latex.beamer'
 'name': 'LaTeX Beamer'
-'fileTypes': []
+'fileTypes': ['tex']
 'contentRegex': '^\\\\documentclass(\\[.*\\])?\\{beamer\\}'
 'patterns': [
   {


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to this repository!

Before you submit, please make sure you fill out the sections below and update the CHANGELOG.md file.
-->

### Description of the Change
<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->

Uses the `contentRegex` property contingent on https://github.com/atom/first-mate/pull/109 and https://github.com/atom/atom/pull/18499 to look for `\documentclass{beamer}` over multiple lines, and apply a penalty if it fails.


### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

The current score method for `firstLineMatch` does not apply a penalty for failures, and Beamer was sometimes getting an edge over LaTeX when it shouldn't. This new property does penalize failure, so works well.


### Benefits
<!-- What benefits will be realized by the code change? -->

Beamer will be auto applied


### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the code change? -->

NA. It would take some weird source to trick it into matching wrongly.


### Applicable Issues
<!-- Enter any applicable Issues here -->

https://github.com/area/language-latex/issues/189