### PR TITLE
Adding `\verb|...|` tag snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ based on http://keepachangelog.com/en/1.0.0/
 ### Added
 - Source text for preview image ([#195](https://github.com/area/language-latex/pull/195)).
 - Support for `\regexp{...}` command ([#196](https://github.com/area/language-latex/pull/196)).
-
+- Support for `\verb|...|`, the inline code command ([]()).
 
 ## [1.2.0] - 2018-09-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ based on http://keepachangelog.com/en/1.0.0/
 ### Added
 - Source text for preview image ([#195](https://github.com/area/language-latex/pull/195)).
 - Support for `\regexp{...}` command ([#196](https://github.com/area/language-latex/pull/196)).
-- Snippet for `\verb|...|`, the inline code command ([]()).
+- Snippet for `\verb|...|`, the inline code command ([#206](https://github.com/area/language-latex/pull/206)).
 
 ## [1.2.0] - 2018-09-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ based on http://keepachangelog.com/en/1.0.0/
 ### Added
 - Source text for preview image ([#195](https://github.com/area/language-latex/pull/195)).
 - Support for `\regexp{...}` command ([#196](https://github.com/area/language-latex/pull/196)).
-- Support for `\verb|...|`, the inline code command ([]()).
+- Snippet for `\verb|...|`, the inline code command ([]()).
 
 ## [1.2.0] - 2018-09-23
 ### Added

--- a/snippets/language-latex.cson
+++ b/snippets/language-latex.cson
@@ -102,6 +102,9 @@
   'inline math - \\(\\)':
     'prefix': 'inline'
     'body': '\\\\($1\\\\)$0'
+  'verbatim':
+    'prefix': 'verb'
+    'body': '\\\\verb|$1|'
 
 # math, taken from  https://github.com/SublimeText/LaTeXTools/blob/master/LaTeX%20math.sublime-completions
 '.text.tex.latex .string.other.math':


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to this repository!

Before you submit, please make sure you fill out the sections below and update the CHANGELOG.md file.
-->

### Description of the Change
<!-- We must be able to understand the design of your change from this description, so please walk us through the concepts. -->

I've added a snippet for verbatim tag `\verb|...|`. This tag is designed for writing inline code.

### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

I don't know... Just the possibility of writing the snippet in other *section* of the file. 

### Benefits
<!-- What benefits will be realized by the code change? -->

The possibility of use quickly the verbatim tag. When you are writing something related to source code, it's very useful. The way this tag works is not very common, and is very easy to made mistakes using it *manually*.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the code change? -->

Just could be drawbacks if anybody wants to use this `prefix` for another thing. 

### Applicable Issues
<!-- Enter any applicable Issues here -->
