### PR TITLE
Add filetypes for memoir and beamer grammars

### DIFF
--- a/grammars/latex-beamer.cson
+++ b/grammars/latex-beamer.cson
@@ -1,6 +1,8 @@
 'scopeName': 'text.tex.latex.beamer'
 'name': 'LaTeX Beamer'
-'fileTypes': []
+'fileTypes': [
+  'tex'
+]
 'firstLineMatch': '^\\\\documentclass(\\[.*\\])?\\{beamer\\}'
 'patterns': [
   {

--- a/grammars/latex-memoir.cson
+++ b/grammars/latex-memoir.cson
@@ -1,6 +1,8 @@
 'scopeName': 'text.tex.latex.memoir'
 'name': 'LaTeX Memoir'
-'fileTypes': []
+'fileTypes': [
+  'tex'
+]
 'firstLineMatch': '^\\\\documentclass(\\[.*\\])?\\{memoir\\}'
 'patterns': [
   {


### PR DESCRIPTION
Wthout `fileTypes`, the `firstLineMatch` is never tested and the grammar is never used.