### PR TITLE
Add support for sisl/pygments-julia lexer

### DIFF
--- a/grammars/latex.cson
+++ b/grammars/latex.cson
@@ -970,7 +970,7 @@
     ]
   }
   {
-    'begin': '(?:\\s*)(((\\\\)begin)(\\{)(minted)(\\})(?:(\\[).*(\\]))?(\\{)(julia|jl)(\\})(\\s*%.*\\n?)?)'
+    'begin': '(?:\\s*)(((\\\\)begin)(\\{)(minted)(\\})(?:(\\[).*(\\]))?(\\{)(julia|jl|julia1|jlcon1)(\\})(\\s*%.*\\n?)?)'
     'captures':
       '1':
         'name': 'meta.function.embedded.latex'


### PR DESCRIPTION
The lexer provided by https://github.com/sisl/pygments-julia is vastly superior to the standard julia lexer. This PR adds support for this lexer and the two environments that it provides.
