### PR TITLE
Added support for \binom{}{} and \intertext{}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ based on http://keepachangelog.com/en/1.0.0/
 ### Added
 - Source text for preview image ([#195](https://github.com/area/language-latex/pull/195)).
 - Support for `\regexp{...}` command ([#196](https://github.com/area/language-latex/pull/196)).
-- Snippets for `\binom` and `\intertext` in equations ([]())
+- Snippets for `\binom` and `\intertext` in equations ([#209](https://github.com/area/language-latex/pull/209))
 
 
 ## [1.2.0] - 2018-09-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ based on http://keepachangelog.com/en/1.0.0/
 ### Added
 - Source text for preview image ([#195](https://github.com/area/language-latex/pull/195)).
 - Support for `\regexp{...}` command ([#196](https://github.com/area/language-latex/pull/196)).
+- Snippets for `\binom` and `\intertext` in equations ([]())
 
 
 ## [1.2.0] - 2018-09-23

--- a/snippets/language-latex.cson
+++ b/snippets/language-latex.cson
@@ -105,6 +105,9 @@
 
 # math, taken from  https://github.com/SublimeText/LaTeXTools/blob/master/LaTeX%20math.sublime-completions
 '.text.tex.latex .string.other.math':
+  'intertext':
+    'prefix': 'inter'
+    'body': '\\\\intertext{$1}$0'
   'math italic':
     'prefix': 'it'
     'body': '\\\\mathit{$1}$0'
@@ -129,6 +132,9 @@
   'fraction':
     'prefix': 'frac'
     'body': '\\\\frac{$1}{$2}$0'
+  'binomial':
+    'prefix': 'binom'
+    'body': '\\\\binom{$1}{$2}$0'
   'aligned':
     'prefix': 'aligned'
     'body': '\\\\begin{aligned}$1\n\t$0\n\\\\end{aligned}'


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to this repository!

Before you submit, please make sure you fill out the sections below and update the CHANGELOG.md file.
-->

### Description of the Change
I added support for autocompletion of `\binom{}{}` and `\intertext{}` for use within
  equations.


### Alternate Designs
This design was selected due to the absence of support for these common commands.


### Benefits
Users will be able to more quickly add binomials and right-justified text to their equations.


### Possible Drawbacks
There is a potential for having too many snippets, although binomials are very common.


### Applicable Issues
No issues.
